### PR TITLE
Update for the NeIC 2019 conference

### DIFF
--- a/extra_css/white.css
+++ b/extra_css/white.css
@@ -16,7 +16,7 @@ body {
 
 .reveal {
   font-family: "Source Sans Pro", Helvetica, sans-serif;
-  font-size: 36px;
+  font-size: 60px;
   font-weight: normal;
   color: #222; }
 
@@ -44,7 +44,7 @@ body {
 .reveal h4,
 .reveal h5,
 .reveal h6 {
-  margin: 0 0 20px 0;
+  margin: 50px 0 20px 0;
   color: #222;
   font-family: "Source Sans Pro", Helvetica, sans-serif;
   font-weight: 600;
@@ -58,7 +58,7 @@ body {
   color: #EEE;
   font-size: 2.5em;
   padding-left: 230px;
-  padding-top: 270px; }
+  padding-top: 300px; }
 .reveal h2 {
   font-size: 1.6em; }
 
@@ -178,6 +178,7 @@ body {
 .reveal table th,
 .reveal table td {
   text-align: left;
+  font-size: 40px;
   padding: 0.2em 0.5em 0.2em 0.5em;
   border: 1px solid; }
 

--- a/html/index.html
+++ b/html/index.html
@@ -56,8 +56,8 @@
     Reveal.initialize({
         history: true,
         center: false,
-        width: 1024,
-        height: 768,
+        width: 1280,
+        height: 1024,
         // More info https://github.com/hakimel/reveal.js#dependencies
         dependencies: [
             {src: 'plugin/markdown/marked.js'},

--- a/markdown/01_intro.md
+++ b/markdown/01_intro.md
@@ -41,17 +41,30 @@ Note:
 * Standardize software deployment
 * Build once, run anywhere
 * Everything needed to run an app in a single package
+* Enabler for standardized infrastructure
 
 ---
 
 ## What is Rahti?
 
 * A new service from CSC
-* Container cloud platform based on **OpenShift** - Red Hat's distribution of **Kubernetes**
+* Container cloud platform based on **OKD** - Red Hat's open source distribution of **Kubernetes**
+* OKD is the upstream version of **OpenShift**
 * Run applications packaged as **containers**
 * Status
   * Currently in **closed beta**
-  * **Production in 2019** - open beta some time before that
+  * **Production in 2019** - open beta coming soon
+
+---
+
+## Key features
+
+* Run your own apps
+* Autorecovery
+* Source-to-image (S2I)
+* Autoscaling
+* Application catalog
+* Easy default TLS & URL for app
 
 ---
 
@@ -89,22 +102,21 @@ Note:
 
 ---
 
-## Cloud platform features
+## Comparison to other platforms
 
-|                    | Pouta | Rahti |
-|--------------------|:-----:|:-----:|
-| Self-service       | ✓     | ✓     |
-| REST API           | ✓     | ✓     |
-| Persistent storage | ✓     | ✓     |
-| Network isolation  | ✓     | ✓     |
-| Load balancing     | DIY   | ✓     |
-| TLS                | DIY   | ✓     |
-| Fault tolerance    | DIY   | ✓     |
-| Autoscaling        | DIY   | ✓     |
+|                           | VMware          | OpenStack   | OKD / Kubernetes  |
+| ------------------------- | --------------- | ----------- | ----------------- |
+| **Model**                 | pet VMs         | cattle VMs  | cattle containers |
+| **Unit**                  | VM              | VM          | container         |
+| **Avail for single unit** | high            | medium      | low               |
+| **Automatic recovery**    | yes             | DIY         | yes               |
+| **Level of abstraction**  | medium          | low         | high              |
+| **Ease of scaling**       | low             | medium      | trivial           |
+| **Non-Linux workloads**   | yes             | yes         | hard              |
 
 ===
 
-# Simplified workflow example
+# Workflow example
 
 <!-- .slide: data-background="img/topic_background.png" -->
 
@@ -153,13 +165,12 @@ Note:
 
 * Open source, hosted by a foundation (CNCF)
 * Backing from tech giants, including:
-   * Google
-   * Red Hat
-   * Microsoft
-   * Cisco
-   * Oracle
-   * AWS
-* **$4 billion** in investments
+  * Google
+  * Red Hat
+  * Microsoft
+  * Cisco
+  * Oracle
+  * AWS
 
 ---
 
@@ -178,13 +189,7 @@ Note:
 
 ---
 
-### One of the most active open source projects
-
-![TOP 30 open source projects](img/top30-opensource-projects.png)
-
----
-
-## Sites that run on Kubernetes
+## Sites that use Kubernetes
 
 ![New York Times](img/ny_times_logo.png)
 


### PR DESCRIPTION
- Set reveal.js resolution to 1280x1024 instead of 1024x768, tweak CSS
  accordingly
- In the intro, mention OKD in addition to OpenShift and Kubernetes
- Update info on open beta ("coming soon")
- List key features, drop comparison to Pouta
- Add table comparison between OKD/K8s, VMware and OpenStack
- Remove "$4 billion in investments" bullet that doesn't have a source
- Remove old top 30 open source project picture as it is from 2016-2017
- Slightly change wording: "Sites that run on Kubernetes" -> "Sites that
  use Kubernetes"